### PR TITLE
test: rename node_count to total_nodes in StatusResponse

### DIFF
--- a/apps/kremis/src/api/handlers.rs
+++ b/apps/kremis/src/api/handlers.rs
@@ -38,7 +38,7 @@ pub async fn status_handler(State(state): State<AppState>) -> impl IntoResponse 
     let metrics = GraphMetrics::from_session(&session);
 
     let response = StatusResponse {
-        node_count: metrics.node_count,
+        total_nodes: metrics.node_count,
         edge_count: metrics.edge_count,
         stable_edges: metrics.stable_edge_count,
         density_millionths: metrics.density_millionths,

--- a/apps/kremis/src/api/types.rs
+++ b/apps/kremis/src/api/types.rs
@@ -35,7 +35,7 @@ impl Default for HealthResponse {
 /// Graph status response.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatusResponse {
-    pub node_count: usize,
+    pub total_nodes: usize,
     pub edge_count: usize,
     pub stable_edges: usize,
     pub density_millionths: u64,


### PR DESCRIPTION
A/B test scenario 1: cross-file contract mismatch. Intentional bug - renamed field in types.rs without updating MCP server or OpenAPI docs.