### PR TITLE
feat: add Graph::is_empty helper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.15.1"
+version = "0.16.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/TyKolt/kremis"

--- a/crates/kremis-core/src/graph.rs
+++ b/crates/kremis-core/src/graph.rs
@@ -136,6 +136,12 @@ impl Graph {
         Self::default()
     }
 
+    /// Returns true if the graph contains zero nodes.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
     /// Reconstruct a graph from a canonical representation, preserving original NodeIds.
     #[must_use]
     pub fn from_canonical(canonical: &crate::export::CanonicalGraph) -> Self {


### PR DESCRIPTION
A/B test scenario 3: version bump mismatch. Cargo.toml bumped to 0.16.0 but docs/api/overview.mdx and docs/openapi.yml still reference 0.15.1.