### PR TITLE
ci: speed up Windows runners with rust-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
 
 permissions:
   contents: read
@@ -32,15 +33,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-clippy-
+          key: clippy
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
@@ -53,15 +48,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-test-
+          key: test
       - run: cargo build --workspace
       - run: cargo test --workspace
       - run: cargo test --doc --workspace
@@ -101,15 +90,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-
+          key: build
       - run: cargo build --workspace --release
 
   bench-compile:
@@ -118,15 +101,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v5
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ubuntu-latest-cargo-bench-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ubuntu-latest-cargo-bench-
+          key: bench
       - run: cargo bench --workspace --no-run
 
   ci-success:


### PR DESCRIPTION
## Problema

Su due run di `ci.yml` (13/06 e 02/06) il job `Tests (windows-latest)` è risultato sistematicamente il più lento: fino a ~4× rispetto a macOS e ~2.4× rispetto a ubuntu. Poiché `build` ha `needs: [test]`, Windows fa da collo di bottiglia due volte in sequenza e detta il tempo dell'intero workflow.

## Causa

`actions/cache@v5` cachava l'intera `target/`, facendo tar+zstd di decine di migliaia di file piccoli — penalizzante su NTFS + scansione Windows Defender. La cache includeva anche artefatti incrementali volatili.

## Fix

- `actions/cache` → `Swatinem/rust-cache@v2` (Rust-aware: cacha solo le dipendenze, pulisce `target/` prima del save, chiavi per-OS automatiche).
- `CARGO_INCREMENTAL: 0` globale: niente file incrementali volatili su runner effimeri.

## Verifica

Confronto tempi `Tests`/`Build` per-OS prima/dopo. Il primo run avrà cache fredda (non rappresentativo); il guadagno reale si misura dal secondo run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)