### PR TITLE
ci: run release build in parallel with tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
   build:
     name: Build (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    needs: [fmt, clippy, test]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problema

Il wall-clock della CI su `main` è ~8m, con la **critical path interamente su Windows**: i due job più lenti girano serializzati.

| Job | Windows | Ubuntu | macOS |
|-----|--------:|-------:|------:|
| Tests | 3m13s | 1m10s | 1m18s |
| Build (release) | 4m46s | 1m10s | 1m19s |

Il job `build` aveva `needs: [fmt, clippy, test]`, quindi la build release partiva solo **dopo** che l'intera matrice test (incluso il lento `Tests (windows)`) era finita: `Tests(windows)` → `Build(windows)` in serie.

## Fix

Rimosso il `needs` dal job `build`: ora gira **in parallelo** agli altri job. Wall-clock atteso ~8m → ~5m (limitato dal solo `Build (windows)`).

## Sicurezza

La protezione di merge è **invariata**: il gate `ci-success` ha già `needs: [fmt, clippy, test, audit, openapi, build, bench-compile]` con `if: always()` e fallisce se un qualsiasi job non è `success`. Cambia *quando* gira la build, non *cosa* viene verificato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)