### PR TITLE
ci: run security audit on dependency changes + daily schedule

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,37 @@
+name: Security Audit
+
+# Per la raccomandazione RustSec, l'audit gira solo quando le dipendenze
+# cambiano (paths su Cargo.toml/Cargo.lock) piu' un controllo giornaliero
+# che intercetta nuove advisory pubblicate contro dipendenze gia' presenti.
+# In questo modo non si paga la compilazione di cargo-audit (~3m) su ogni
+# commit code-only, senza perdere copertura di sicurezza.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,18 +55,6 @@ jobs:
       - run: cargo test --workspace
       - run: cargo test --doc --workspace
 
-  audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v7
-      - uses: rustsec/audit-check@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
   openapi:
     name: OpenAPI Lint
     runs-on: ubuntu-latest
@@ -108,7 +96,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, test, audit, openapi, build, bench-compile]
+    needs: [fmt, clippy, test, openapi, build, bench-compile]
     if: always()
     steps:
       - name: Check all jobs passed
@@ -116,7 +104,6 @@ jobs:
           if [[ "${{ needs.fmt.result }}" != "success" ]] || \
              [[ "${{ needs.clippy.result }}" != "success" ]] || \
              [[ "${{ needs.test.result }}" != "success" ]] || \
-             [[ "${{ needs.audit.result }}" != "success" ]] || \
              [[ "${{ needs.openapi.result }}" != "success" ]] || \
              [[ "${{ needs.build.result }}" != "success" ]] || \
              [[ "${{ needs.bench-compile.result }}" != "success" ]]; then


### PR DESCRIPTION
## Problema

Dopo aver parallelizzato il job `build` (#56), il wall-clock CI è ~3m38s ed è ora limitato da **`Security Audit` (3m25s)**, non più da Windows. Quel job:
- ricompila `cargo-audit` da sorgente **ad ogni commit** (anche code-only);
- è l'unico **flaky** — il fallimento su `13b3023` era un errore di rete proprio durante quella compilazione.

## Fix (raccomandazione RustSec)

L'audit non si accelera cambiando *come* si installa (la doc `cargo-audit` raccomanda esplicitamente `rustsec/audit-check`, **non** `cargo install`), ma cambiando *quando* gira. Spostato in un workflow dedicato `audit.yml`:
- **`paths: [Cargo.toml, Cargo.lock]`** su push/PR → gira solo quando le dipendenze cambiano (quando un dep vulnerabile può entrare);
- **`schedule` giornaliero** → intercetta advisory nuove pubblicate contro dipendenze già presenti (finestra ≤24h);
- **`workflow_dispatch`** → esecuzione manuale.

Rimosso `audit` dal gate aggregato `ci-success`.

## Effetto

- Commit code-only: niente più tax da ~3m + niente flake → wall-clock **~3m38s → ~3m**.
- Copertura di sicurezza preservata su entrambi i vettori (dep-change + schedule daily).
- Su **questa** PR il workflow `audit.yml` **non** si attiva (non tocca `Cargo.*`): è la dimostrazione del paths filter.

## Note

I **Test su Windows (~3m)** restano il prossimo limite, ma è linking single-thread MSVC: `nextest` parallelizza l'esecuzione non il link (~30-40s), `sccache` rallenta le release build fino al 50%. `rust-cache` (leva documentata) è già in uso. Nessun intervento qui per evitare ottimizzazione speculativa a ROI incerto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)