### PR TITLE
ci: use rust-lld for Windows test linking (experiment)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+      # Windows-only: the default MSVC linker is single-threaded and dominates
+      # the per-test-binary link time. rust-lld links those binaries in
+      # parallel. Scoped to this CI job (debug, no LTO) so it never touches
+      # release builds or local dev. Set before rust-cache so the flag is
+      # folded into the Windows cache key.
+      - name: Use rust-lld on Windows
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: echo "RUSTFLAGS=-C linker-features=+lld" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@v2
         with:
           key: test


### PR DESCRIPTION
## Ipotesi (basata su ricerca)

`Tests (windows)` è il soffitto del wall-clock CI (~3-4m, alta varianza). Causa documentata: il **linker MSVC di default è single-thread** e ogni binario di test è linkato separatamente. `rust-lld` linka in parallelo (~2x su full build secondo Embark Studios).

## Approccio

`RUSTFLAGS=-C linker-features=+lld` impostato **solo sul job test della CI per Windows**, mai in `.cargo/config.toml` → release build e dev locale Windows mantengono il linker di default (i bug noti di `lld-link` su MSVC restano fuori dall'artefatto distribuito).

## Validazione

- **Run 1 (questo)**: cache fredda (nuovo RUSTFLAGS = nuova chiave). Serve a verificare la **correttezza** — i test passano con lld? niente undefined symbols / access violation?
- **Run 2 (caldo)**: misura reale del guadagno su `Tests (windows)`.

Tenuto **solo se** misurabilmente più veloce con test verdi; revert altrimenti (la ricerca avverte che il guadagno è project-dependent, in un caso 0.7% più lento).

🤖 Generated with [Claude Code](https://claude.com/claude-code)