### PR TITLE
ci: use lld-link for Windows test linking (experiment)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+      # Windows-only: the default MSVC linker (link.exe) is single-threaded and
+      # dominates the per-test-binary link time. lld-link (LLVM, preinstalled on
+      # the GitHub Windows image) links in parallel. Stable-toolchain mechanism
+      # via -C linker, scoped to this CI job only (debug, no LTO) so release
+      # builds and local Windows dev keep the default linker. Set before
+      # rust-cache so the flag is folded into the Windows cache key.
+      - name: Use lld-link on Windows
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: echo "RUSTFLAGS=-C linker=lld-link.exe" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@v2
         with:
           key: test


### PR DESCRIPTION
Esperimento: `RUSTFLAGS=-C linker=lld-link.exe` (lld di LLVM, preinstallato sul runner Windows) solo sul job test CI per Windows. Meccanismo **stable** (a differenza di `-C linker-features=+lld` che è nightly-only, PR #58 chiusa). Obiettivo: parallelizzare il linking dei binari di test, oggi collo del wall-clock (~3-4m).

Scope CI-only → release build e dev locale Windows mantengono il linker di default. Run 1 = cache fredda (verifica correttezza: niente undefined symbols / access violation con lld). Run 2 caldo = misura. Tenuto solo se più veloce con test verdi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)