### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -30,6 +30,7 @@ jobs:
     permissions:
       checks: write
       contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v7
       - uses: rustsec/audit-check@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Kremis are documented in this file.
 
+## [0.19.5] - 2026-06-23
+
+### Bug Fixes
+
+- *(deps)* Bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185) ([`67f0f54`](https://github.com/TyKolt/kremis/commit/67f0f547ca75fa8930479f9ac8acff732860c741))
+
+### Dependencies
+
+- *(deps)* Bump the rust-all-updates group with 2 updates ([#55](https://github.com/TyKolt/kremis/issues/55)) ([`f56353e`](https://github.com/TyKolt/kremis/commit/f56353ed0d3eb8599c0b723910eaa70636fa9953))
+
 ## [0.19.4] - 2026-06-22
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "kremis"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "axum",
  "axum-test",
@@ -1409,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "kremis-core"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "blake3",
  "criterion",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "kremis-mcp"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "reqwest",
  "rmcp",
@@ -1856,9 +1856,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.19.4"
+version = "0.19.5"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/TyKolt/kremis"

--- a/apps/kremis/tests/types_tests.rs
+++ b/apps/kremis/tests/types_tests.rs
@@ -23,12 +23,12 @@ fn test_health_response_default() {
 fn test_health_response_serialization() {
     let health = HealthResponse {
         status: "ok".to_string(),
-        version: "0.19.4".to_string(),
+        version: "0.19.5".to_string(),
     };
 
     let json = serde_json::to_string(&health).unwrap();
     assert!(json.contains("\"status\":\"ok\""));
-    assert!(json.contains("\"version\":\"0.19.4\""));
+    assert!(json.contains("\"version\":\"0.19.5\""));
 }
 
 #[test]

--- a/docs/api/health.mdx
+++ b/docs/api/health.mdx
@@ -15,7 +15,7 @@ icon: "heart-pulse"
 ```json 200 OK
 {
   "status": "ok",
-  "version": "0.19.4"
+  "version": "0.19.5"
 }
 ```
 

--- a/docs/api/overview.mdx
+++ b/docs/api/overview.mdx
@@ -5,7 +5,7 @@ icon: "code"
 ---
 
 **Base URL:** `http://localhost:8080`
-**Version:** 0.19.4
+**Version:** 0.19.5
 **License:** Apache 2.0
 
 ## Endpoints

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -2,7 +2,7 @@ openapi: 3.1.0
 
 info:
   title: Kremis API
-  version: 0.19.4
+  version: 0.19.5
   description: |
     Kremis is a deterministic, graph-based memory engine for AI agents.
 
@@ -67,7 +67,7 @@ paths:
                 $ref: "#/components/schemas/HealthResponse"
               example:
                 status: ok
-                version: "0.19.4"
+                version: "0.19.5"
         "429":
           $ref: "#/components/responses/TooManyRequests"
 
@@ -724,7 +724,7 @@ components:
         version:
           type: string
           description: Server version (semver).
-          example: "0.19.4"
+          example: "0.19.5"
 
     # -------------------------------------------------------------------------
     # Graph state


### PR DESCRIPTION
## Cosa

Risolve l'advisory **RUSTSEC-2026-0185** intercettato dal Security Audit schedulato del 2026-06-23.

`quinn-proto 0.11.14` (dipendenza transitiva via `reqwest` in `apps/kremis-mcp`) è affetto da *remote memory exhaustion* dovuto al reassembly non limitato di stream QUIC out-of-order (DoS, CVSS A:H). Patchato in `0.11.15`.

## Modifiche

- `cargo update -p quinn-proto` → 0.11.15 (sola dipendenza transitiva toccata)
- PATCH bump `0.19.4 → 0.19.5` propagato sui file canonici
- `issues: write` aggiunto al job Security Audit: su run schedulate `rustsec/audit-check` apriva una issue di tracking ma falliva con *Resource not accessible by integration*

## Verifiche

- `cargo audit` locale: RUSTSEC-2026-0185 risolta (resta solo il warning informativo `atomic-polyfill`, consentito)
- Pre-commit gate: fmt + clippy -D warnings + check + test → tutti verdi

🤖 Generated with [Claude Code](https://claude.com/claude-code)