### PR TITLE
ci: ignore RUSTSEC-2023-0089 in security audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -36,3 +36,9 @@ jobs:
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Permanent Exemption (vedi .claude/generated/project-facts.md):
+          # RUSTSEC-2023-0089 atomic-polyfill unmaintained -- transitivo via
+          # postcard 1.1.x -> heapless 0.7 -> atomic-polyfill. Non sfruttabile
+          # (unmaintained, non vuln); risolvibile solo con postcard 2.0 (non
+          # rilasciato). Senza questo ignore l'action ricrea l'issue ogni giorno.
+          ignore: RUSTSEC-2023-0089


### PR DESCRIPTION
## Cosa

Aggiunge `ignore: RUSTSEC-2023-0089` allo step `rustsec/audit-check@v2` in `.github/workflows/audit.yml`.

## Perché

`RUSTSEC-2023-0089` è un advisory **unmaintained** (non una vulnerabilità sfruttabile) su `atomic-polyfill`, tirato dentro in modo transitivo:

```
kremis-core -> postcard 1.1.3 -> heapless 0.7.17 -> atomic-polyfill 1.0.3
```

`postcard 1.1.3` è l'ultima 1.x e fissa `heapless ^0.7`. La catena si spezza solo con `postcard 2.0` (non ancora rilasciato): nessun upgrade azionabile dalla nostra parte. È già una **Permanent Exemption** documentata in `.claude/generated/project-facts.md`.

Il run schedulato giornaliero di `audit-check` ricreava automaticamente un'issue ogni notte (#61, chiusa). Questo `ignore` ferma la ricreazione mantenendo piena copertura su ogni altra advisory. Da rivedere quando esce `postcard 2.0`.

## Note

- Commit `ci:` → nessun version bump (regola semver).
- Il path-filter del workflow non scatta su modifiche a `audit.yml`; l'effetto si vedrà al prossimo run schedulato/dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)