### PR TITLE
deps(deps): bump crossbeam-epoch 0.9.18 -> 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Cosa

Bump di `crossbeam-epoch` `0.9.18` → `0.9.20` per risolvere **RUSTSEC-2026-0204**.

## Perché

Invalid pointer dereference nell'impl `fmt::Pointer` per `Atomic` e `Shared` quando il puntatore sottostante è invalido (es. `Atomic::null` / `Shared::null`). Patchato in `>=0.9.20`.

## Esposizione

Dipendenza **transitiva** e **dev-only**: arriva unicamente da `criterion` (benchmark). Nessun impatto sui binari spediti o sul codice di produzione. Fix richiesto per far passare il job `audit` della CI.

## Verifica

- `cargo update -p crossbeam-epoch` → lockfile-only, nessun `Cargo.toml` toccato (nessun version bump: non è `feat:`/`fix:`)
- `cargo audit` → RUSTSEC-2026-0204 risolto
- Gate pre-commit: `fmt --check` ✓ · `clippy -D warnings` ✓ · `check --all-targets` ✓ · `test --workspace` ✓

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)