### PR TITLE
ci(benchmark): publish the deviation the parser was throwing away

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -99,7 +99,12 @@ jobs:
           def format_measure(ns, dev):
               div, prec, unit = unit_of(ns)
               out = f"{ns / div:.{prec}f} {unit}"
-              if dev:
+              # `is not None`, not truthiness: a deviation of 0 is REPORTED and
+              # zero, which is the strongest thing the table can say about a
+              # figure. Truthiness would render it identically to a deviation
+              # that was never measured -- the same conflation this whole
+              # change exists to remove.
+              if dev is not None:
                   out += f" \u00b1{dev / div:.{prec}f}"
               return out
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -84,22 +84,46 @@ jobs:
 
           OS_ORDER = ["ubuntu-latest", "windows-latest", "macos-latest"]
 
-          def format_ns(ns):
+          # Unit is chosen from the value, then reused for its deviation: a band
+          # rendered in a different unit than the figure it qualifies is worse
+          # than no band at all.
+          def unit_of(ns):
               if ns >= 1_000_000_000:
-                  return f"{ns / 1_000_000_000:.1f} s"
+                  return 1_000_000_000, 1, "s"
               if ns >= 1_000_000:
-                  return f"{ns / 1_000_000:.2f} ms"
+                  return 1_000_000, 2, "ms"
               if ns >= 1_000:
-                  return f"{ns / 1_000:.1f} \u00b5s"
-              return f"{ns} ns"
+                  return 1_000, 1, "\u00b5s"
+              return 1, 0, "ns"
 
+          def format_measure(ns, dev):
+              div, prec, unit = unit_of(ns)
+              out = f"{ns / div:.{prec}f} {unit}"
+              if dev:
+                  out += f" \u00b1{dev / div:.{prec}f}"
+              return out
+
+          # criterion's bencher format emits the deviation:
+          #     test strongest_path/1000 ... bench:  11,790 ns/iter (+/- 1,918)
+          # Until 2026-08-16 the pattern ended at "ns/iter" and that tail was
+          # dropped, so the README published four significant figures for a
+          # measurement whose own run reported +/- 16%. The uncertainty was
+          # measured, carried all the way here, and discarded at the last step.
+          # The group is optional: a missing deviation degrades to a bare value,
+          # never to a crash.
           def parse_bench(path):
               results = {}
               with open(path) as f:
                   for line in f:
-                      m = re.match(r"test (.+?)\s+\.\.\. bench:\s+([\d,]+) ns/iter", line)
+                      m = re.match(
+                          r"test (.+?)\s+\.\.\. bench:\s+([\d,]+) ns/iter"
+                          r"(?:\s+\(\+/-\s+([\d,]+)\))?",
+                          line,
+                      )
                       if m:
-                          results[m.group(1)] = int(m.group(2).replace(",", ""))
+                          ns = int(m.group(2).replace(",", ""))
+                          dev = int(m.group(3).replace(",", "")) if m.group(3) else None
+                          results[m.group(1)] = (ns, dev)
               return results
 
           # Parse results per OS
@@ -125,9 +149,9 @@ jobs:
               values = []
               has_any = False
               for o in os_present:
-                  ns = all_results[o].get(name)
-                  if ns is not None:
-                      values.append(format_ns(ns))
+                  measure = all_results[o].get(name)
+                  if measure is not None:
+                      values.append(format_measure(*measure))
                       has_any = True
                   else:
                       values.append("\u2014")
@@ -145,7 +169,13 @@ jobs:
               "",
               header,
               separator,
-          ] + rows)
+          ] + rows + [
+              "",
+              "> The ± is criterion's deviation within a single run. Spread *between* runs",
+              "> on hosted CI is wider still, because the runners themselves vary: figures",
+              "> here have moved by tens of percent with no change to the benched code.",
+              "> Read them as orders of magnitude, not as a regression signal.",
+          ])
 
           section = f"<!-- BENCHMARK-START -->\n{table}\n<!-- BENCHMARK-END -->"
 


### PR DESCRIPTION
## What this changes

`criterion`'s bencher output carries a deviation on every line. The parser's pattern ended at `ns/iter`, so it was dropped:

```
test strongest_path/1000 ... bench:      11,790 ns/iter (+/- 1,918)
                                                         ^^^^^^^^^^ matched by nothing
```

The uncertainty was measured, uploaded as an artifact, downloaded, and discarded one step before the table that needed it.

## Why it matters

Six benchmarks measured on one machine, one run each:

| bench | deviation |
|---|---:|
| node_insertion/100000 | 12.8% |
| signal_ingestion/sequence/10000 | 14.1% |
| import_canonical/10000 | 12.9% |
| export_canonical/1000 | 16.9% |
| traverse/depth_50/1000 | 18.4% |
| strongest_path/1000 | 19.9% |

Between-run spread is wider. The two most recent runs changed **no benched code** — only `Cargo.lock`, and none of the bumped crates is linked into this bench (`blake3` is optional behind `crypto-hash`, and `default = []`) — yet the macOS column moved by up to **78%**.

The table printed four significant figures for a quantity that supports about one. Anything under roughly a quarter of the value was indistinguishable from noise, and nothing said so.

## Result

Produced by running the workflow's own embedded script against real criterion output from this branch:

```
| Operation | Linux |
|-----------|------:|
| Node insertion (100K) | 43.06 ms ±5.52 |
| Signal ingestion (10K batch) | 20.55 ms ±2.90 |
| Graph traversal (depth 50, 1K nodes) | 7.2 µs ±1.3 |
| Strongest path (1K nodes) | 12.8 µs ±2.5 |
| Canonical export (1K nodes) | 110.8 µs ±18.7 |
| Canonical import (10K nodes) | 6.06 ms ±0.78 |

> The ± is criterion's deviation within a single run. Spread *between* runs
> on hosted CI is wider still, because the runners themselves vary: figures
> here have moved by tens of percent with no change to the benched code.
> Read them as orders of magnitude, not as a regression signal.
```

Those figures are this machine's, not CI's, and are slower than the runners'. They are here to show the rendering, not to state performance.

## Notes for review

- The deviation group is **optional**: a line without one degrades to a bare value, never to a crash.
- The unit is chosen from the value and reused for its band, since a band in a different unit is worse than none.
- No version bump: `ci:` only, no crate touched.
- This workflow runs `on: push: branches: [main]`, so **it will not run on this PR**. The table above is the local reproduction that stands in for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)