### PR TITLE
ci(benchmark): the parser required the tool to stay quiet

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -116,19 +116,36 @@ jobs:
           # measured, carried all the way here, and discarded at the last step.
           # The group is optional: a missing deviation degrades to a bare value,
           # never to a crash.
+          # Name and measurement are matched SEPARATELY because they are not always
+          # on the same line. When criterion cannot read a previous baseline it
+          # prints to stdout, in the middle of the record:
+          #
+          #     test node_insertion/100 ... Criterion.rs ERROR: error: Failed to
+          #     bench:       7,845 ns/iter (+/- 203)
+          #
+          # A single-line pattern matches neither half. On 2026-08-16 that produced
+          # 65 such records per runner and zero parsed results on all three, and
+          # the job died on "No matching benchmark results found". The workflow had
+          # been depending on a warm target/criterion for the tool to stay quiet --
+          # a parser that breaks when its input becomes talkative depends on silence,
+          # not on structure.
+          NAME_RE = re.compile(r"^test (.+?)\s+\.\.\.")
+          BENCH_RE = re.compile(r"bench:\s+([\d,]+) ns/iter(?:\s+\(\+/-\s+([\d,]+)\))?")
+
           def parse_bench(path):
               results = {}
+              pending = None
               with open(path) as f:
                   for line in f:
-                      m = re.match(
-                          r"test (.+?)\s+\.\.\. bench:\s+([\d,]+) ns/iter"
-                          r"(?:\s+\(\+/-\s+([\d,]+)\))?",
-                          line,
-                      )
-                      if m:
-                          ns = int(m.group(2).replace(",", ""))
-                          dev = int(m.group(3).replace(",", "")) if m.group(3) else None
-                          results[m.group(1)] = (ns, dev)
+                      nm = NAME_RE.match(line)
+                      if nm:
+                          pending = nm.group(1)
+                      bm = BENCH_RE.search(line)
+                      if bm and pending is not None:
+                          ns = int(bm.group(1).replace(",", ""))
+                          dev = int(bm.group(2).replace(",", "")) if bm.group(2) else None
+                          results[pending] = (ns, dev)
+                          pending = None
               return results
 
           # Parse results per OS


### PR DESCRIPTION
## The failure

Run [31942859289](https://github.com/TyKolt/kremis/actions/runs/31942859289): all three `Bench` jobs succeeded, `Update README` exited 1 with `No matching benchmark results found`. The README still carries the previous table.

## Cause

criterion could not read a baseline it expected and reported it **on stdout**, inside the record it was writing:

```
test node_insertion/100 ... Criterion.rs ERROR: error: Failed to access file ".../base/sample.json"
bench:       7,845 ns/iter (+/- 203)
```

The name and the measurement land on different lines. A single-line pattern matches neither half.

## Not a regression from the previous PR

Measured on the three artifacts of the failing run:

| artifact | lines | old pattern | new pattern | ERROR lines | orphaned `bench:` |
|---|---:|---:|---:|---:|---:|
| bench-ubuntu-latest | 144 | **0** | **0** | 65 | 65 |
| bench-windows-latest | 144 | **0** | **0** | 65 | 65 |
| bench-macos-latest | 144 | **0** | **0** | 65 | 65 |

The pattern that shipped before deviation-parsing scores zero on this input too. The job had been depending on a warm `target/criterion` for the tool to have nothing to say.

## Fix

Name and measurement are matched separately, so a record split across lines parses exactly like one that is not.

## Verification

The workflow's own embedded script, run against the artifacts of the failing run, **unmodified**:

```
exit code: 0   (the CI run exited 1)
stdout: Updated 7 benchmark entries across 3 OS

| Operation | Linux | Windows | macOS |
|-----------|------:|------:|------:|
| Node insertion (100K) | 22.28 ms ±0.07 | 16.69 ms ±0.82 | 15.50 ms ±0.64 |
| Signal ingestion (10K batch) | 8.63 ms ±0.19 | 8.83 ms ±0.54 | 6.11 ms ±0.43 |
| Graph traversal (depth 50, 1K nodes) | 2.8 µs ±0.0 | 2.6 µs ±0.0 | 2.0 µs ±0.1 |
| Strongest path (1K nodes) | 8.1 µs ±0.0 | 6.8 µs ±0.1 | 6.9 µs ±0.8 |
| Canonical export (1K nodes) | 72.8 µs ±0.7 | 60.1 µs ±1.0 | 48.7 µs ±2.7 |
| Canonical import (10K nodes) | 3.21 ms ±0.01 | 3.00 ms ±0.08 | 2.98 ms ±0.18 |
| Redb node insertion (1K) | 354.88 ms ±15.25 | 18.4 s ±0.3 | 412.83 ms ±133.17 |
```

Generated README verified as valid UTF-8.

## Note for review

These real deviations make the accompanying note load-bearing rather than decorative. Within-run spread on Linux is **0.3%–4.3%**, while the same figures have moved by more than 20% *between* runs — macOS `Node insertion` went 25.58 ms to 15.50 ms, −39%, against a ±4.1% band. A tight ± printed without that caveat would buy apparent precision at the cost of the real thing.

- No version bump: `ci:` only.
- This workflow runs `on: push: branches: [main]`, so it will not run on this PR. The verification above stands in for it, on stronger input than a fresh run would provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)